### PR TITLE
Update commit sort logic to use parents instead

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,20 +77,20 @@ jobs:
           hdiutil attach "$DMG_PATH"
           
           # Debug: List contents of the mounted volume
-          VOLUME_PATH=$(ls /Volumes | grep "GitVisor")
+          VOLUME_PATH=$(ls /Volumes | grep "Git Visor")
           ls -al "/Volumes/$VOLUME_PATH/"
           
           # Copy the app to Applications folder
-          cp -R "/Volumes/$VOLUME_PATH/GitVisor.app" /Applications/
+          cp -R "/Volumes/$VOLUME_PATH/Git Visor.app" /Applications/
           
           # Open the app to verify it launches
-          open /Applications/GitVisor.app
+          open /Applications/Git Visor.app
           
           # Wait for a few seconds to ensure it runs
           sleep 10
           
           # Check if the app is running
-          pgrep -f "GitVisor" || (echo "App failed to launch" && exit 1)
+          pgrep -f "Git Visor" || (echo "App failed to launch" && exit 1)
           
           # Detach the .dmg
           hdiutil detach "/Volumes/$VOLUME_PATH"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,7 +93,7 @@ jobs:
           pgrep -f "Git Visor" || (echo "App failed to launch" && exit 1)
           
           # Detach the .dmg
-          hdiutil detach "/Volumes/$VOLUME_PATH"
+          hdiutil detach "$VOLUME_PATH"
 
       # Upload the built artifacts (exe, dmg, AppImage) to the GitHub Action Run page
       - name: Upload Artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,14 +77,14 @@ jobs:
           hdiutil attach "$DMG_PATH"
           
           # Debug: List contents of the mounted volume
-          VOLUME_PATH=$(ls /Volumes | grep "Git Visor")
+          VOLUME_PATH="$(find /Volumes -maxdepth 1 -type d -name "Git Visor*" | head -n 1)"
           ls -al "/Volumes/$VOLUME_PATH/"
           
           # Copy the app to Applications folder
           cp -R "/Volumes/$VOLUME_PATH/Git Visor.app" /Applications/
           
           # Open the app to verify it launches
-          open /Applications/Git Visor.app
+          open "/Applications/Git Visor.app"
           
           # Wait for a few seconds to ensure it runs
           sleep 10

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,10 +78,10 @@ jobs:
           
           # Debug: List contents of the mounted volume
           VOLUME_PATH="$(find /Volumes -maxdepth 1 -type d -name "Git Visor*" | head -n 1)"
-          ls -al "/Volumes/$VOLUME_PATH/"
+          ls -al "$VOLUME_PATH/"
           
           # Copy the app to Applications folder
-          cp -R "/Volumes/$VOLUME_PATH/Git Visor.app" /Applications/
+          cp -R "$VOLUME_PATH/Git Visor.app" /Applications/
           
           # Open the app to verify it launches
           open "/Applications/Git Visor.app"

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -12,7 +12,7 @@ files:
 asarUnpack:
   - resources/**
 win:
-  executableName: GitVisor
+  executableName: Git Visor
   icon: resources/GitVisor-simple-transparent-bg-lg.ico
   target:
     - target: nsis
@@ -32,7 +32,7 @@ mac:
   entitlementsInherit: null
   gatekeeperAssess: false
   notarize: false
-  executableName: GitVisor
+  executableName: Git Visor
 dmg:
   artifactName: ${name}-${version}.${ext}
 linux:

--- a/src/renderer/src/app/components/ObjectGraph.tsx
+++ b/src/renderer/src/app/components/ObjectGraph.tsx
@@ -60,7 +60,7 @@ export function ObjectGraph({
     tag: new Path2D("M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.828 8.828a2 2 0 0 0 2.828 0l7.172-7.172a2 2 0 0 0 0-2.828z M7.5 7.5h.01")
   }), [])
 
-  // 1. Calculate Initial Layout TODO: Handle merges somehow
+  // 1. Calculate Initial Layout
   const defaultPositions = useMemo(() => {
     const positionMap = new Map<string, NodePosition>()
     const objectMap = new Map(objects.map((o) => [o.hash, o]))
@@ -79,15 +79,24 @@ export function ObjectGraph({
         }
       }
     }
-    const queue = commitNodes
-      .filter((c) => (childCount.get(c.hash) ?? 0) === 0)
-      .sort((a, b) => Number(b.timestamp ?? 0) - Number(a.timestamp ?? 0))
-
+    const compareCommits = (a: CommitObject, b: CommitObject): number => {
+      const ta = Number(a.timestamp ?? 0)
+      const tb = Number(b.timestamp ?? 0)
+      if (ta !== tb) return tb - ta
+      return a.hash.localeCompare(b.hash)
+    }
+    // technically no need to stable sort since current branch handling ensures the commit history is linear, but just be safe
+    const enqueueSorted = (arr: CommitObject[], item: CommitObject): void => {
+      let i = 0
+      while (i < arr.length && compareCommits(arr[i], item) <= 0) i++
+      arr.splice(i, 0, item)
+    }
+    const queue = commitNodes.filter((c) => (childCount.get(c.hash) ?? 0) === 0)
     const commits: CommitObject[] = []
     const seen = new Set<string>()
-
-    while (queue.length > 0) {
-      const current = queue.shift()!
+    let queueIndex = 0
+    while (queueIndex < queue.length) {
+      const current = queue[queueIndex++]!
       if (seen.has(current.hash)) continue
       seen.add(current.hash)
       commits.push(current)
@@ -98,15 +107,14 @@ export function ObjectGraph({
         childCount.set(p, nextCount)
         if (nextCount === 0) {
           const parentCommit = commitByHash.get(p)
-          if (parentCommit) queue.push(parentCommit)
+          if (parentCommit) enqueueSorted(queue, parentCommit)
         }
       }
     }
 
     // fallback in case of disconnected/corrupt commit links
-    for (const c of commitNodes) {
-      if (!seen.has(c.hash)) commits.push(c)
-    }
+    const remaining = commitNodes.filter((c) => !seen.has(c.hash)).sort(compareCommits)
+    for (const c of remaining) commits.push(c)
 
     const treeReachableCache = new Map<string, Set<string>>()
     const getReachableFromTree = (rootTreeHash: string): Set<string> => {

--- a/src/renderer/src/app/components/ObjectGraph.tsx
+++ b/src/renderer/src/app/components/ObjectGraph.tsx
@@ -66,15 +66,47 @@ export function ObjectGraph({
     const objectMap = new Map(objects.map((o) => [o.hash, o]))
     const rowToY = (row: number): number => row * ROW_HEIGHT + NODE_TO_LABELS_GAP
 
-    const commits = objects
+    const commitNodes = objects
       .filter((o) => o.type === 'commit')
       .map((o) => o as CommitObject)
-      .sort((a, b) => {
-        const at = Number(a.timestamp ?? 0)
-        const bt = Number(b.timestamp ?? 0)
-        if (at !== bt) return at - bt
-        return a.hash.localeCompare(b.hash)
-      })
+
+    const commitByHash = new Map(commitNodes.map((c) => [c.hash, c]))
+    const childCount = new Map<string, number>(commitNodes.map((c) => [c.hash, 0]))
+    for (const c of commitNodes) {
+      for (const p of c.parent ?? []) {
+        if (childCount.has(p)) {
+          childCount.set(p, (childCount.get(p) ?? 0) + 1)
+        }
+      }
+    }
+    const queue = commitNodes
+      .filter((c) => (childCount.get(c.hash) ?? 0) === 0)
+      .sort((a, b) => Number(b.timestamp ?? 0) - Number(a.timestamp ?? 0))
+
+    const commits: CommitObject[] = []
+    const seen = new Set<string>()
+
+    while (queue.length > 0) {
+      const current = queue.shift()!
+      if (seen.has(current.hash)) continue
+      seen.add(current.hash)
+      commits.push(current)
+
+      for (const p of current.parent ?? []) {
+        if (!childCount.has(p)) continue
+        const nextCount = (childCount.get(p) ?? 0) - 1
+        childCount.set(p, nextCount)
+        if (nextCount === 0) {
+          const parentCommit = commitByHash.get(p)
+          if (parentCommit) queue.push(parentCommit)
+        }
+      }
+    }
+
+    // fallback in case of disconnected/corrupt commit links
+    for (const c of commitNodes) {
+      if (!seen.has(c.hash)) commits.push(c)
+    }
 
     const treeReachableCache = new Map<string, Set<string>>()
     const getReachableFromTree = (rootTreeHash: string): Set<string> => {


### PR DESCRIPTION
Fix #43 

Updated sort logic s.t. the top commit has no children and the commit node below is the parent